### PR TITLE
Defining directives with ES6 classes have issues

### DIFF
--- a/packages/core/src/directive.js
+++ b/packages/core/src/directive.js
@@ -93,9 +93,8 @@ const directiveProvider = moduleName => {
         originalDirective = { compile: originalDirective };
       }
 
-      const result = {
-        [$originalCompile]: originalDirective.compile,
-      };
+      const result = Object.create(Object.getPrototypeOf(originalDirective));
+      result[$originalCompile] = originalDirective.compile;
 
       return Object.assign(result, originalDirective, {
         compile() {


### PR DESCRIPTION
Hi,

First of all thanks for all your work, this tool is amazing.

I have one issue though regarding directives. More specifically in cases where the directive is defined with an ES6 class. Something similar to the example here: https://www.michaelbromley.co.uk/blog/exploring-es6-classes-in-angularjs-1.x/#directives

When defining a directive this way the `compile` and `link` functions will be properties on the prototype of the directive object rather than its own properties. In the case of `compile` I don't think it is problematic as you are copying it to a new property [here](https://github.com/noppa/ng-hot-reload/blob/master/packages/core/src/directive.js#L97). But in the case of the `link` function, it will be lost as the result object will not have the prototype of the original directive. I suggest a small change to copy the prototype of the original directive to the new one too. This way the `link` will be available on the result directive too.

In my case, the suggested change resolved the issue and I don't think it should cause any problems elsewhere. I hope you can accept this change or improve it to solve my issue.

Thanks!